### PR TITLE
Album implementation and dependency removal

### DIFF
--- a/src/api/ApiHandlerClient.java
+++ b/src/api/ApiHandlerClient.java
@@ -2,6 +2,7 @@ package api.src.api;
 
 import se.michaelthelin.spotify.SpotifyApi;
 import se.michaelthelin.spotify.model_objects.credentials.ClientCredentials;
+import se.michaelthelin.spotify.model_objects.specification.Album;
 import se.michaelthelin.spotify.model_objects.specification.AudioFeatures;
 import se.michaelthelin.spotify.model_objects.specification.Track;
 
@@ -31,6 +32,16 @@ public class ApiHandlerClient implements ApiHandler {
         try {
             assert checkIsAuthenticated();
             return API.getAudioFeaturesForTrack(id).build().execute();
+        } catch (Exception e) {
+            System.out.println("Exception: " + e.getMessage());
+        }
+        return null;
+    }
+
+    public Album makeAlbumRequest(String id) {
+        try {
+            assert checkIsAuthenticated();
+            return API.getAlbum(id).build().execute();
         } catch (Exception e) {
             System.out.println("Exception: " + e.getMessage());
         }

--- a/src/entities/Album.java
+++ b/src/entities/Album.java
@@ -1,30 +1,30 @@
 package api.src.entities;
+
+import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
+import se.michaelthelin.spotify.model_objects.specification.Image;
+
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+
 public class Album {
+    private final String id;
+    private String title;
+    private ArrayList<Song> songs;
+    private ArrayList<String> artists;
+    private ArrayList<BufferedImage> coverImages;
+    private String yearReleased;
 
-    private final String title;
-    private final Song[] songs;
-
-    private final String artist;
-
-    private final String cover;
-
-    private final Integer yearReleased;
-
-    Album(String title, Song[] songs, String artist, String cover, Integer yearReleased) {
-        this.title = title;
-        this.songs = songs;
-        this.artist = artist;
-        this.cover = cover;
-        this.yearReleased = yearReleased;
+    Album(String id, AlbumFactory factory) {
+        this.id = id;
+        factory.create(this);
     }
 
-    public String getTitle() {return title; }
-
-    public Song[] getSongs() {return songs; }
-
-    public String getArtist() {return artist; }
-
-    public String getCover() {return cover; }
-
-    public Integer getYearReleased() {return yearReleased; }
+    public String getId() {return id;}
+    public String getTitle() {return title;}
+    public void setTitle(String title) {this.title = title;}
+    public ArrayList<Song> getSongs() {return songs;}
+    public ArrayList<String> getArtists() {return artists;}
+    public ArrayList<BufferedImage> getCoverImages() {return coverImages;}
+    public String getYearReleased() {return yearReleased;}
+    public void setYearReleased(String year) {this.yearReleased = year;}
 }

--- a/src/entities/AlbumFactory.java
+++ b/src/entities/AlbumFactory.java
@@ -1,0 +1,5 @@
+package api.src.entities;
+
+public interface AlbumFactory {
+    void create(Album album);
+}

--- a/src/entities/Song.java
+++ b/src/entities/Song.java
@@ -1,26 +1,26 @@
 package api.src.entities;
 
-import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
+import java.util.ArrayList;
 
 public class Song {
     private final String id;
     private String title;
-    private ArtistSimplified[] artists;
+    private ArrayList<String> artists;
     private double popularity;
     private double danceability;
     private String yearReleased;
     private Album album;
 
-    public Song(String id) {
+    public Song(String id, SongFactory factory) {
         this.id = id;
+        factory.create(this);
     }
 
     public String getID() {return id;}
     public String getTitle() {return title; }
     public void setTitle(String title) {this.title = title;}
 
-    public ArtistSimplified[] getArtists() {return artists;}
-    public void setArtists(ArtistSimplified[] artists) {this.artists = artists;}
+    public ArrayList<String> getArtists() {return artists;}
 
     public double getPopularity() {return popularity; }
     public void setPopularity(double popularity) {this.popularity = popularity;}

--- a/src/entities/SpotifyApiAlbumFactory.java
+++ b/src/entities/SpotifyApiAlbumFactory.java
@@ -1,0 +1,46 @@
+package api.src.entities;
+
+import api.src.api.ApiHandlerClient;
+import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
+import se.michaelthelin.spotify.model_objects.specification.Image;
+import se.michaelthelin.spotify.model_objects.specification.Paging;
+import se.michaelthelin.spotify.model_objects.specification.TrackSimplified;
+
+import javax.imageio.ImageIO;
+import java.io.IOException;
+import java.net.URL;
+
+public class SpotifyApiAlbumFactory implements AlbumFactory {
+    ApiHandlerClient api;
+
+    public SpotifyApiAlbumFactory(ApiHandlerClient api) {this.api = api;}
+    @Override
+    public void create(Album album) {
+        se.michaelthelin.spotify.model_objects.specification.Album spotifyAlbum =
+                api.makeAlbumRequest(album.getId());
+
+        album.setTitle(spotifyAlbum.getName());
+        album.setYearReleased(spotifyAlbum.getReleaseDate());
+
+        Image[] images = spotifyAlbum.getImages();
+        for (Image i : images) {
+            try {
+                album.getCoverImages().add(ImageIO.read(new URL(i.getUrl())));
+            } catch (IOException e) {
+                System.out.println("Exception: " + e.getMessage());
+            }
+        }
+
+        ArtistSimplified[] artists = spotifyAlbum.getArtists();
+        for (ArtistSimplified i : artists) {
+            album.getArtists().add(i.getName());
+        }
+
+        Paging<TrackSimplified> tracks = spotifyAlbum.getTracks();
+        for (TrackSimplified i : tracks.getItems()) {
+            album.getSongs().add(
+                    new Song(i.getId(), new SpotifyApiSongFactory(api))
+            ); // Iterate through all the TrackSimplified-s and create Song objects
+        }
+    }
+}

--- a/src/entities/SpotifyApiSongFactory.java
+++ b/src/entities/SpotifyApiSongFactory.java
@@ -1,6 +1,7 @@
 package api.src.entities;
 
 import api.src.api.ApiHandlerClient;
+import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
 import se.michaelthelin.spotify.model_objects.specification.AudioFeatures;
 import se.michaelthelin.spotify.model_objects.specification.Track;
 
@@ -16,9 +17,14 @@ public class SpotifyApiSongFactory implements SongFactory {
         AudioFeatures a = api.makeAudioFeaturesRequest(song.getID());
 
         song.setTitle(t.getName());
-        song.setArtists(t.getArtists());
         song.setPopularity(t.getPopularity());
         song.setDanceability(a.getDanceability());
-        // song.setYearReleased(); needs album implementation
+        song.setAlbum(
+                new Album(t.getAlbum().getId(), new SpotifyApiAlbumFactory(api)));
+        song.setYearReleased(song.getAlbum().getYearReleased());
+
+        for (ArtistSimplified i : t.getArtists()) {
+            song.getArtists().add(i.getName());
+        }
     }
 }


### PR DESCRIPTION
Finished Album class so it can be instantiated. AlbumFactory interface and SpotifyApiAlbumFactory were also created so that the details can be filled in without Album being directly dependent on the API.

Song was also reconfigured to remove its dependency on ArtistSimplified.

Both Artist and Song constructors were changed so that you pass them a factory when they are instantiated, instead of having to create the factory and call the create() method afterwards.